### PR TITLE
Drop setting of removed org-node-extra-id-dirs

### DIFF
--- a/lisp/toncs-config-org-roam.org
+++ b/lisp/toncs-config-org-roam.org
@@ -55,7 +55,6 @@
   (setq org-node-file-slug-fn #'org-node-slugify-like-roam-default)
   (setq org-node-file-timestamp-format "%Y%m%d%H%M%S-")
 
-  (add-to-list 'org-node-extra-id-dirs org-roam-directory)
   (org-mem-updater-mode)
   (org-node-cache-mode)
   (org-node-roam-accelerator-mode))


### PR DESCRIPTION
org-node 3.0.0 renamed `org-node-extra-id-dirs` to `org-mem-watch-dirs`, leaving only a `:renamed-3.0.0` sentinel constant. `add-to-list` on the sentinel signals `wrong-type-argument listp` when the org-roam config runs. `org-mem-watch-dirs` already contains `org-roam-directory`, so the line can simply go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)