### PR TITLE
Update lib/orderless submodule

### DIFF
--- a/lisp/toncs-config.org
+++ b/lisp/toncs-config.org
@@ -354,7 +354,7 @@ FEATURE の読み込み前に設定しておきたい変数の初期化処理や
    consult-line
    :add-history (seq-some #'thing-at-point '(region symbol)))
 
-  (setq orderless-component-separator #'orderless-escapable-split-on-space)
+  (setq orderless-component-separator #'orderless-escapable-split)
 
   (setq xref-show-xrefs-function #'consult-xref)
   (setq xref-show-definitions-function #'consult-xref)


### PR DESCRIPTION
- lib/orderless: 31812d9..0ffd9d6
- lisp/toncs-config.org: orderless-component-separator の参照先を orderless-escapable-split-on-space から orderless-escapable-split へ更新（関数リネームに追従）