### PR TITLE
Update lib/pulsar submodule

### DIFF
--- a/lisp/toncs-config.org
+++ b/lisp/toncs-config.org
@@ -868,7 +868,6 @@ FEATURE の読み込み前に設定しておきたい変数の初期化処理や
 (require 'pulsar)
 
 (toncs-config-configure pulsar
-  (setq pulsar-pulse t)
   (setq pulsar-delay 0.05)
   (setq pulsar-iterations 20)
   (setq pulsar-face 'pulsar-blue)


### PR DESCRIPTION
- lib/pulsar: 77416e6..2155112
- lisp/toncs-config.org: pulsar-pulse の設定を削除（1.3.0 で obsolete 化・内部でのパルス制御方式に置き換えられ機能しなくなったため）